### PR TITLE
Support full Yubico OATH AID

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -754,7 +754,7 @@ impl<'l> Credential<'l> {
 
 impl<T> iso7816::App for Authenticator<T> {
     fn aid(&self) -> iso7816::Aid {
-        iso7816::Aid::new(&crate::YUBICO_OATH_AID)
+        iso7816::Aid::new_truncatable(&crate::YUBICO_OATH_AID, crate::YUBICO_OATH_AID_TRUNCATED_LEN)
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -384,11 +384,10 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
 impl<'l, const C: usize> TryFrom<&'l Data<C>> for Select<'l> {
     type Error = Status;
     fn try_from(data: &'l Data<C>) -> Result<Self, Self::Error> {
-        // info_now!("comparing {} against {}", hex_str!(data.as_slice()), hex_str!(crate::YUBICO_OATH_AID));
-        Ok(match data.as_slice() {
-            crate::YUBICO_OATH_AID => Self { aid: data },
-            _ => return Err(Status::NotFound),
-        })
+        if crate::YUBICO_OATH_AID.starts_with(data.as_slice()) {
+            return Ok(Self { aid: data});
+        }
+        Err(Status::NotFound)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ pub mod state;
 pub const YUBICO_RID: [u8; 5] = hex!("A000000 527");
 // pub const YUBICO_OTP_PIX: [u8; 3] = hex!("200101");
 // pub const YUBICO_OTP_AID: &[u8] = &hex!("A000000527 2001 01");
-pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101");// 01");
+pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101 01");
+pub const YUBICO_OATH_AID_TRUNCATED_LEN: usize = 7;
 
 // class AID(bytes, Enum):
 //     OTP = b'\xa0\x00\x00\x05\x27 \x20\x01'


### PR DESCRIPTION
Some clients, like Yubico Authenticator on Android, use the full AID for the OATH app, while the Trussed impl is one byte shorter and so isn't currently recognised.

See for example [the Yubico Authenticator source](https://github.com/Yubico/yubioath-android/blob/master/app/src/main/java/com/yubico/yubikitold/application/oath/OathApplication.java#L29).

This change just bumps the AID out per your original comment. I have to apologise, I'm not in a position to test it myself (still waiting on a solo2 hacker key).