### PR TITLE
Counter should be 8 bytes long

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -501,11 +501,11 @@ where
                         postcard_serialize_bytes(&credential).unwrap(),
                         None
                     ));
-
+                    let counter_long: u64 = counter.into();
                     crate::calculate::calculate(
                         &mut self.trussed,
                         credential.algorithm,
-                        &counter.to_be_bytes(),
+                        &counter_long.to_be_bytes(),
                         credential.secret,
                     )
                 } else {


### PR DESCRIPTION
With counter size equal to 4 bytes the test vectors do not pass back the right values for HOTP. Similarly, the TOTP implementation uses 8 byte long int, hence it seems that this is a typo. At the same time the YK's protocol does accept only 4-byte counters.

As per RFC4226, 5.1. Notation and Symbols [1]:
```
   C       8-byte counter value, the moving factor.  This counter
           MUST be synchronized between the HOTP generator (client)
           and the HOTP validator (server).
```

[1] https://www.rfc-editor.org/rfc/rfc4226#page-5