### PR TITLE
Directly use postcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ heapless-bytes = "0.3"
 hex-literal = "0.3"
 interchange = "0.2"
 iso7816 = "0.1"
+postcard = "0.7"
 serde = { version = "1", default-features = false }
 trussed = "0.1"
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,6 @@ use iso7816::Status;
 // use iso7816::response::Result;
 
 use trussed::{
-    postcard_deserialize, postcard_serialize_bytes,
     syscall, try_syscall,
     types::{KeyId, Location, PathBuf},
 };
@@ -84,7 +83,7 @@ impl State {
         // NB: This is an attack vector. If the state can be corrupted, this clears the password.
         // Consider resetting the device in this situation
         let mut state: Persistent = try_syscall!(trussed.read_file(Location::Internal, PathBuf::from(Self::FILENAME)))
-            .map(|response| postcard_deserialize(&response.data).unwrap())
+            .map(|response| postcard::from_bytes(&response.data).unwrap())
             .unwrap_or_else(|_| {
                 let salt: [u8; 8] = syscall!(trussed.random_bytes(8)).bytes.as_ref().try_into().unwrap();
                 Persistent { salt, authorization_key: None }
@@ -97,7 +96,7 @@ impl State {
         syscall!(trussed.write_file(
             Location::Internal,
             PathBuf::from(Self::FILENAME),
-            postcard_serialize_bytes(&state).unwrap(),
+            postcard::to_vec(&state).unwrap().into(),
             None,
         ));
 
@@ -121,7 +120,7 @@ impl State {
         // NB: This is an attack vector. If the state can be corrupted, this clears the password.
         // Consider resetting the device in this situation
         let mut state: Persistent = try_syscall!(trussed.read_file(Location::Internal, PathBuf::from(Self::FILENAME)))
-            .map(|response| postcard_deserialize(&response.data).unwrap())
+            .map(|response| postcard::from_bytes(&response.data).unwrap())
             .unwrap_or_else(|_| {
                 let salt: [u8; 8] = syscall!(trussed.random_bytes(8)).bytes.as_ref().try_into().unwrap();
                 Persistent { salt, authorization_key: None }
@@ -134,7 +133,7 @@ impl State {
         syscall!(trussed.write_file(
             Location::Internal,
             PathBuf::from(Self::FILENAME),
-            postcard_serialize_bytes(&state).unwrap(),
+            postcard::to_vec(&state).unwrap().into(),
             None,
         ));
         x


### PR DESCRIPTION
This patch replaces the postcard re-exports from Trussed with using postcard directly.  The postcard usage in this app is not related to Trussed at all, so we should not depend on it.